### PR TITLE
Use authentication for InfluxDB

### DIFF
--- a/public/data.php
+++ b/public/data.php
@@ -9,7 +9,7 @@
 		die(json_encode(['error' => 'No influx host found.']));
 	}
 
-	$influxClient = new InfluxDB\Client($config['influx']['host'], $config['influx']['port']);
+	$influxClient = new InfluxDB\Client($config['influx']['host'], $config['influx']['port'], $config['influx']['user'], $config['influx']['pass']);
 	$influxDatabase = $influxClient->selectDB($config['influx']['db']);
 	if (!$influxDatabase->exists()) {
 		die(json_encode(['error' => 'No influx db found.']));

--- a/public/submit.php
+++ b/public/submit.php
@@ -35,7 +35,7 @@
 
 	// Check if we have Influx
 	if (!empty($config['influx']['host'])) {
-		$influxClient = new InfluxDB\Client($config['influx']['host'], $config['influx']['port']);
+		$influxClient = new InfluxDB\Client($config['influx']['host'], $config['influx']['port'], $config['influx']['user'], $config['influx']['pass']);
 		$influxDatabase = $influxClient->selectDB($config['influx']['db']);
 		if (!$influxDatabase->exists()) { $influxDatabase->create(); }
 	} else {


### PR DESCRIPTION
1. Use authentication for InfluxDB
2. Fix Syntax issue in data.php
> It is very important to note that the line with the closing identifier must contain no other characters, except a semicolon (;). That means especially that the identifier may not be indented, and there may not be any spaces or tabs before or after the semicolon. It's also important to realize that the first character before the closing identifier must be a newline as defined by the local operating system. This is \n on UNIX systems, including Mac OS X. The closing delimiter must also be followed by a newline.
> 
> If this rule is broken and the closing identifier is not "clean", it will not be considered a closing identifier, and PHP will continue looking for one. If a proper closing identifier is not found before the end of the current file, a parse error will result at the last line.
